### PR TITLE
Fix #14: 子任务完成按钮

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -231,6 +231,26 @@ main {
     margin: 5px 0;
     background: #f8f9fa;
     border-radius: 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.subtask-item.completed {
+    opacity: 0.6;
+    text-decoration: line-through;
+}
+
+.subtask-status.completed {
+    color: #28a745;
+    font-weight: bold;
+    margin-left: auto;
+}
+
+.btn-sm {
+    padding: 2px 10px;
+    font-size: 12px;
+    margin-left: auto;
 }
 
 .loading {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -141,6 +141,13 @@ function renderTasks() {
         });
     });
 
+    container.querySelectorAll('.btn-complete-subtask').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            const taskId = parseInt(e.target.dataset.taskId);
+            completeTask(taskId);
+        });
+    });
+
     // 更新状态栏中的简要统计
     updateStatusBar();
 }
@@ -162,10 +169,12 @@ function createTaskHTML(task) {
     const subtasksHTML = task.subtasks && task.subtasks.length > 0
         ? `<div class="subtasks">
             ${task.subtasks.map(st => `
-                <div class="subtask-item">
+                <div class="subtask-item ${st.status === 'completed' ? 'completed' : ''}">
                     <span class="task-badge ${st.category}">${categoryLabels[st.category]}</span>
                     ${st.title}
-                    ${st.status === 'completed' ? '✓' : ''}
+                    ${st.status === 'completed' 
+                        ? '<span class="subtask-status completed">✓ 已完成</span>'
+                        : `<button class="btn btn-sm btn-success btn-complete-subtask" data-task-id="${st.id}">✓ 完成</button>`}
                 </div>
             `).join('')}
            </div>`


### PR DESCRIPTION
## 修复 Issue #14: 拆解的子任务无法点击完成

### 问题
子任务在主任务内显示，但没有完成按钮，用户无法标记子任务为已完成。主任务完成按钮提示需先完成子任务，但子任务本身无完成入口。

### 修复内容
- **frontend/js/app.js**: 为未完成子任务添加「✓ 完成」按钮，复用已有 complete API；已完成子任务显示删除线
- **frontend/css/styles.css**: 添加完成状态样式和按钮样式

### 测试
- 创建主任务 → 拆解子任务 → 点击子任务完成按钮 → 状态正确更新
- 所有子任务完成后，主任务可以正常完成