### PR TITLE
fix: 修复添加任务失败 + 简化创建表单 (#21 #22)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     github_repo: Optional[str] = None
     github_token: Optional[str] = None
 
+    # AI 子任务生成 API 配置（环境变量：MODEL_URL, MODEL_NAME, MODEL_KEY）
+    model_url: Optional[str] = None
+    model_name: Optional[str] = None
+    model_key: Optional[str] = None
+
     # 日志配置
     log_level: str = "INFO"
 

--- a/backend/app/orchestrator/subtask_generator.py
+++ b/backend/app/orchestrator/subtask_generator.py
@@ -1,0 +1,110 @@
+"""AI 子任务生成器 - 调用外部 AI API 自动生成子任务"""
+
+import json
+import logging
+from typing import List, Optional
+import httpx
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def generate_subtasks(title: str, description: Optional[str] = None) -> List[str]:
+    """
+    调用 AI API 根据任务标题和描述生成子任务列表
+
+    Args:
+        title: 任务标题
+        description: 任务描述（可选）
+
+    Returns:
+        子任务标题列表，失败时返回空列表
+    """
+    model_url = settings.model_url
+    model_name = settings.model_name
+    model_key = settings.model_key
+
+    if not model_url or not model_name or not model_key:
+        logger.info("AI 子任务生成未配置（MODEL_URL/MODEL_NAME/MODEL_KEY），跳过自动生成")
+        return []
+
+    prompt = _build_prompt(title, description)
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                model_url,
+                headers={
+                    "Authorization": f"Bearer {model_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model_name,
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": (
+                                "你是一个任务管理助手。用户会给你一个任务描述，"
+                                "你需要将这个任务拆解为 2-5 个具体可执行的子任务。"
+                                "只返回 JSON 数组格式，不要其他内容。"
+                                "示例：[\"子任务1\", \"子任务2\", \"子任务3\"]"
+                            ),
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    "temperature": 0.7,
+                    "max_tokens": 500,
+                },
+            )
+
+            if response.status_code != 200:
+                logger.warning(f"AI API 返回非 200 状态码: {response.status_code}")
+                return []
+
+            data = response.json()
+            content = data["choices"][0]["message"]["content"].strip()
+
+            # 解析 JSON 数组
+            subtasks = _parse_subtasks(content)
+            logger.info(f"AI 生成子任务成功: {len(subtasks)} 个 - {title}")
+            return subtasks
+
+    except Exception as e:
+        logger.warning(f"AI 子任务生成失败（不影响主任务创建）: {e}")
+        return []
+
+
+def _build_prompt(title: str, description: Optional[str] = None) -> str:
+    """构建生成子任务的 prompt"""
+    prompt = f"任务：{title}"
+    if description:
+        prompt += f"\n描述：{description}"
+    prompt += "\n\n请将上述任务拆解为 2-5 个具体可执行的子任务，返回 JSON 数组。"
+    return prompt
+
+
+def _parse_subtasks(content: str) -> List[str]:
+    """从 AI 返回内容中解析子任务列表"""
+    # 尝试直接解析 JSON
+    try:
+        result = json.loads(content)
+        if isinstance(result, list):
+            return [str(item).strip() for item in result if str(item).strip()]
+    except json.JSONDecodeError:
+        pass
+
+    # 尝试提取 JSON 数组
+    import re
+
+    match = re.search(r"\[.*\]", content, re.DOTALL)
+    if match:
+        try:
+            result = json.loads(match.group())
+            if isinstance(result, list):
+                return [str(item).strip() for item in result if str(item).strip()]
+        except json.JSONDecodeError:
+            pass
+
+    # 最后尝试按行分割
+    lines = [line.strip().lstrip("0123456789.-) ") for line in content.split("\n") if line.strip()]
+    return lines if lines else []

--- a/backend/app/orchestrator/subtask_generator.py
+++ b/backend/app/orchestrator/subtask_generator.py
@@ -25,7 +25,9 @@ async def generate_subtasks(title: str, description: Optional[str] = None) -> Li
     model_key = settings.model_key
 
     if not model_url or not model_name or not model_key:
-        logger.info("AI 子任务生成未配置（MODEL_URL/MODEL_NAME/MODEL_KEY），跳过自动生成")
+        logger.info(
+            "AI 子任务生成未配置（MODEL_URL/MODEL_NAME/MODEL_KEY），跳过自动生成"
+        )
         return []
 
     prompt = _build_prompt(title, description)
@@ -47,7 +49,7 @@ async def generate_subtasks(title: str, description: Optional[str] = None) -> Li
                                 "你是一个任务管理助手。用户会给你一个任务描述，"
                                 "你需要将这个任务拆解为 2-5 个具体可执行的子任务。"
                                 "只返回 JSON 数组格式，不要其他内容。"
-                                "示例：[\"子任务1\", \"子任务2\", \"子任务3\"]"
+                                '示例：["子任务1", "子任务2", "子任务3"]'
                             ),
                         },
                         {"role": "user", "content": prompt},
@@ -106,5 +108,9 @@ def _parse_subtasks(content: str) -> List[str]:
             pass
 
     # 最后尝试按行分割
-    lines = [line.strip().lstrip("0123456789.-) ") for line in content.split("\n") if line.strip()]
+    lines = [
+        line.strip().lstrip("0123456789.-) ")
+        for line in content.split("\n")
+        if line.strip()
+    ]
     return lines if lines else []

--- a/backend/app/orchestrator/task_orchestrator.py
+++ b/backend/app/orchestrator/task_orchestrator.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from app.executor import TaskExecutor
 from app.models import Task
 from app.orchestrator.context_manager import ContextManager, Context
+from app.orchestrator.subtask_generator import generate_subtasks
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 import logging
@@ -60,6 +61,10 @@ class TaskOrchestrator:
         else:
             category = self._classify_task(task_info, context)
 
+        # 兜底：确保 category 不为空（数据库 NOT NULL 约束）
+        if not category:
+            category = "life"
+
         # 3. 创建主任务
         task = await self.executor.create_task(
             title=task_info["title"],
@@ -78,6 +83,13 @@ class TaskOrchestrator:
         # 5. 如果需要拆分子任务
         if subtasks:
             for subtask_title in subtasks:
+                await self._create_subtask(task.id, subtask_title, category)
+        else:
+            # 自动生成子任务（AI）
+            auto_subtasks = await generate_subtasks(
+                task_info["title"], description or task_info.get("description")
+            )
+            for subtask_title in auto_subtasks:
                 await self._create_subtask(task.id, subtask_title, category)
 
         # 6. 安排提醒

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -465,3 +465,36 @@ main {
         font-size: 0.95em;
     }
 }
+
+/* Simplified task input */
+.task-input-group {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.task-input-group input {
+    flex: 1;
+    padding: 12px 16px;
+    font-size: 16px;
+    border: 2px solid #e0e0e0;
+    border-radius: 8px;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.task-input-group input:focus {
+    border-color: #4a90d9;
+}
+
+.task-input-group .btn-add {
+    padding: 12px 24px;
+    font-size: 16px;
+    white-space: nowrap;
+}
+
+.form-hint {
+    margin: 8px 0 0 0;
+    font-size: 13px;
+    color: #888;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,55 +46,11 @@
                     <span class="toggle-icon">▼</span>
                 </div>
                 <form id="add-task-form" class="form-content">
-                    <div class="form-group">
-                        <label for="task-title">任务标题 *</label>
-                        <input type="text" id="task-title" required placeholder="输入任务标题...">
+                    <div class="form-group task-input-group">
+                        <input type="text" id="task-input" required placeholder="输入任务描述，AI 将自动拆解子任务..." autocomplete="off">
+                        <button type="submit" class="btn btn-primary btn-add">添加</button>
                     </div>
-
-                    <div class="form-group">
-                        <label for="task-description">任务描述</label>
-                        <textarea id="task-description" rows="3" placeholder="输入任务描述..."></textarea>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label for="task-category">分类</label>
-                            <select id="task-category">
-                                <option value="auto">自动</option>
-                                <option value="work">工作</option>
-                                <option value="life">生活</option>
-                                <option value="education">教育</option>
-                            </select>
-                        </div>
-
-                        <div class="form-group">
-                            <label for="task-priority">优先级</label>
-                            <select id="task-priority">
-                                <option value="0">低</option>
-                                <option value="5">中</option>
-                                <option value="9">高</option>
-                            </select>
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label for="task-due-time">截止时间</label>
-                            <input type="datetime-local" id="task-due-time">
-                        </div>
-
-                        <div class="form-group">
-                            <label for="task-location">地点提醒（JSON格式）</label>
-                            <input type="text" id="task-location" placeholder='{"lat": 31.2304, "lon": 121.4737}'>
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="task-subtasks">子任务（每行一个）</label>
-                        <textarea id="task-subtasks" rows="3" placeholder="输入子任务，每行一个..."></textarea>
-                    </div>
-
-                    <button type="submit" class="btn btn-primary">添加任务</button>
+                    <p class="form-hint">输入任务描述即可，系统将自动分类并生成子任务</p>
                 </form>
             </section>
         </main>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -249,43 +249,20 @@ function formatDateTime(dateString) {
 async function handleAddTask(e) {
     e.preventDefault();
 
-    const title = document.getElementById('task-title').value.trim();
-    const description = document.getElementById('task-description').value.trim();
-    const categorySelect = document.getElementById('task-category').value;
-    const priority = parseInt(document.getElementById('task-priority').value);
-    const dueTime = document.getElementById('task-due-time').value;
-    const location = document.getElementById('task-location').value.trim();
-    const subtasksText = document.getElementById('task-subtasks').value.trim();
+    const input = document.getElementById('task-input').value.trim();
 
-    if (!title) {
-        showError('请输入任务标题');
+    if (!input) {
+        showError('请输入任务描述');
         return;
     }
 
     const taskData = {
-        title,
-        description,
-        priority,
+        title: input,
+        priority: 0,
     };
 
-    if (categorySelect !== 'auto') {
-        taskData.category = categorySelect;
-    }
-
-    if (dueTime) {
-        taskData.due_time = new Date(dueTime).toISOString();
-    }
-
-    if (location) {
-        taskData.location = location;
-    }
-
-    if (subtasksText) {
-        taskData.subtasks = subtasksText.split('\n').filter(st => st.trim());
-    }
-
     try {
-        const response = await fetch(`${API_BASE_URL}/tasks`, {
+        const response = await fetchWithRetry(`${API_BASE_URL}/tasks`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(taskData)
@@ -296,17 +273,17 @@ async function handleAddTask(e) {
             throw new Error(errorData.detail || '添加任务失败');
         }
 
-        // 清空表单
-        document.getElementById('add-task-form').reset();
+        // 清空输入框
+        document.getElementById('task-input').value = '';
 
         // 重新加载任务
         await loadTasks();
         await loadStats();
 
-        showSuccess('任务添加成功！');
+        showSuccess('任务添加成功！AI 正在生成子任务...');
     } catch (error) {
         console.error('添加任务失败:', error);
-        showError('添加任务失败');
+        showError('添加任务失败: ' + (error.message || '未知错误'));
     }
 }
 


### PR DESCRIPTION
## 关联 Issues

Closes #21, Closes #22

### Issue #22: 不能添加新任务
**根因：** 前端选"自动"分类时不传 category，后端 context.category 可能为 None，导致数据库 NOT NULL 约束报错。
**修复：** 在编排器 `create_task` 中添加 category 兜底逻辑，确保分类始终有值。

### Issue #21: 界面简化
**改动：**
- 前端表单简化为单个输入框，用户只需输入任务描述
- 后端新增 `subtask_generator.py`，调用 AI API（MODEL_URL/MODEL_NAME/MODEL_KEY）自动生成子任务
- AI 生成失败时优雅降级，不影响主任务创建

### 修改文件
- `backend/app/config.py` — 添加 MODEL_URL/MODEL_NAME/MODEL_KEY 配置
- `backend/app/orchestrator/task_orchestrator.py` — category 兜底 + 集成子任务生成
- `backend/app/orchestrator/subtask_generator.py` — 新增 AI 子任务生成模块
- `frontend/index.html` — 简化表单为单输入框
- `frontend/js/app.js` — 适配新表单逻辑
- `frontend/css/styles.css` — 新增简化表单样式