### PR TITLE
fix: 修复创建任务时 SQL GROUP BY 错误

### DIFF
--- a/backend/app/executor/task_executor.py
+++ b/backend/app/executor/task_executor.py
@@ -158,12 +158,15 @@ class TaskExecutor:
 
     async def get_location_statistics(self) -> List[Dict[str, Any]]:
         """获取位置统计"""
+        from sqlalchemy import func
+
         # 统计每个IP/位置的任务分类分布
         stats = (
             self.db.query(
-                TaskLocation.ip, TaskLocation.category, Task.id.label("task_count")
+                TaskLocation.ip,
+                TaskLocation.category,
+                func.count(TaskLocation.id).label("task_count"),
             )
-            .join(Task, TaskLocation.task_id == Task.id)
             .group_by(TaskLocation.ip, TaskLocation.category)
             .all()
         )


### PR DESCRIPTION
## 问题

创建任务时调用链：`create_task` → `learn_mapping` → `_auto_generate_rules` → `get_location_statistics`，该函数的 SQL 查询有 GROUP BY 错误：

```
column "tasks.id" must appear in the GROUP BY clause or be used in an aggregate function
```

## 修复

将 `Task.id.label("task_count")` 改为 `func.count(TaskLocation.id).label("task_count")`，正确使用聚合函数。