### PR TITLE
fix: improve task classification for work category

### DIFF
--- a/backend/app/orchestrator/task_orchestrator.py
+++ b/backend/app/orchestrator/task_orchestrator.py
@@ -180,8 +180,9 @@ class TaskOrchestrator:
         # 根据任务内容判断
         title = task_info["title"].lower()
 
-        # 工作相关关键词
+        # 工作相关关键词（优先级最高，优先匹配）
         work_keywords = [
+            "工作",
             "项目",
             "报告",
             "会议",
@@ -191,6 +192,12 @@ class TaskOrchestrator:
             "功能",
             "客户",
             "需求",
+            "周报",
+            "日报",
+            "方案",
+            "策划",
+            "招标",
+            "投标",
         ]
         if any(keyword in title for keyword in work_keywords):
             return "work"


### PR DESCRIPTION
## Summary

Improved the task classification logic to better recognize work-related tasks.

## Changes

- Added "工作" to work_keywords list (main fix for the reported issue)
- Added additional work-related keywords: 周报, 日报, 方案, 策划, 招标, 投标

## Testing

- Verified the fix with the example task "把工作的事情重新安排一下" which now correctly classifies as "work"

Fixes gdyshi/todo-system#33