### PR TITLE
fix: 修复 CI Unit Tests 失败 (NameError + black 格式)

### DIFF
--- a/backend/app/orchestrator/subtask_generator.py
+++ b/backend/app/orchestrator/subtask_generator.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 import httpx
 from app.config import settings
 
@@ -39,9 +39,7 @@ def _is_subtask_of_test(task: Any, tasks_map: Dict[int, Any]) -> bool:
     return False
 
 
-async def generate_subtasks(
-    title: str, description: Optional[str] = None
-) -> List[str]:
+async def generate_subtasks(title: str, description: Optional[str] = None) -> List[str]:
     """
     调用 AI API 根据任务标题和描述生成子任务列表
 


### PR DESCRIPTION
## 问题\nCI/CD Pipeline Unit Tests 失败，2个错误：\n\n1. \subtask_generator.py:30\ — \NameError: name 'Any' is not defined\（缺少 \Any\, \Dict\ 导入）\n2. \subtask_generator.py\ — black 格式化不通过（\generate_subtasks\ 函数签名换行）\n\n## 修复\n- 添加 \rom typing import Any, Dict\ 到导入\n- 将 \generate_subtasks\ 函数签名合并为单行以满足 black 格式要求