### PR TITLE
fix: E2E cleanup 容错处理

### DIFF
--- a/tests/e2e/cleanup-test-data.js
+++ b/tests/e2e/cleanup-test-data.js
@@ -45,6 +45,10 @@ async function cleanupTestData() {
         if (deleteResponse.ok) {
           deletedCount++;
           console.log(`Deleted task: ${task.title} (ID: ${task.id})`);
+        } else if (deleteResponse.status === 404) {
+          // Task already deleted - not an error
+          deletedCount++;
+          console.log(`Task ${task.id} already deleted (404), skipping`);
         } else {
           console.warn(`Failed to delete task ${task.id}: ${deleteResponse.status}`);
         }
@@ -56,11 +60,12 @@ async function cleanupTestData() {
     console.log(`Cleanup complete. Deleted ${deletedCount} of ${testTasks.length} test tasks.`);
 
     if (deletedCount < testTasks.length) {
-      process.exit(1);
+      console.warn(`Warning: Only deleted ${deletedCount} of ${testTasks.length} test tasks`);
+      // Don't exit with error - cleanup best-effort, shouldn't fail CI
     }
   } catch (error) {
     console.error('Error during cleanup:', error.message);
-    process.exit(1);
+    // Don't exit with error - cleanup failure shouldn't fail CI
   }
 }
 


### PR DESCRIPTION
## 问题\nE2E 测试的 cleanup 步骤在测试数据不存在时（404）返回 exit 1，导致 CI 整体失败。\n\n## 修复\n- 404 视为已删除，不报错\n- 删除数量少于预期时输出警告但不 exit 1\n- catch 异常时输出错误但不 exit 1\n\n清理是 best-effort 操作，不应阻断 CI。