### PR TITLE
fix: make task decomposition opt-in, only when user explicitly provides subtasks

### DIFF
--- a/backend/app/orchestrator/task_orchestrator.py
+++ b/backend/app/orchestrator/task_orchestrator.py
@@ -2,7 +2,6 @@ from sqlalchemy.orm import Session
 from app.executor import TaskExecutor
 from app.models import Task
 from app.orchestrator.context_manager import ContextManager, Context
-from app.orchestrator.subtask_generator import generate_subtasks
 from app.config import settings
 from typing import List, Optional, Dict, Any
 from datetime import datetime
@@ -81,16 +80,9 @@ class TaskOrchestrator:
             task_id=task.id, ip=context.ip, location=context.location, category=category
         )
 
-        # 5. 如果需要拆分子任务
+        # 5. 如果用户明确提供了子任务，才拆分
         if subtasks:
             for subtask_title in subtasks:
-                await self._create_subtask(task.id, subtask_title, category)
-        else:
-            # 自动生成子任务（AI）
-            auto_subtasks = await generate_subtasks(
-                task_info["title"], description or task_info.get("description")
-            )
-            for subtask_title in auto_subtasks:
                 await self._create_subtask(task.id, subtask_title, category)
 
         # 6. 安排提醒

--- a/backend/app/orchestrator/task_orchestrator.py
+++ b/backend/app/orchestrator/task_orchestrator.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Session
 from app.executor import TaskExecutor
 from app.models import Task
 from app.orchestrator.context_manager import ContextManager, Context
-from app.orchestrator.subtask_generator import generate_subtasks
+# generate_subtasks 不再自动调用 — 仅在用户明确要求时通过 API 传入子任务
 from app.config import settings
 from typing import List, Optional, Dict, Any
 from datetime import datetime
@@ -81,16 +81,11 @@ class TaskOrchestrator:
             task_id=task.id, ip=context.ip, location=context.location, category=category
         )
 
-        # 5. 如果需要拆分子任务
+        # 5. 如果用户明确指定了子任务，才创建子任务
+        # 不再自动生成子任务 — 只有用户语义中明确要求分解时才分解
+        # （用户通过 API 传入 subtasks 参数即表示明确要求）
         if subtasks:
             for subtask_title in subtasks:
-                await self._create_subtask(task.id, subtask_title, category)
-        else:
-            # 自动生成子任务（AI）
-            auto_subtasks = await generate_subtasks(
-                task_info["title"], description or task_info.get("description")
-            )
-            for subtask_title in auto_subtasks:
                 await self._create_subtask(task.id, subtask_title, category)
 
         # 6. 安排提醒


### PR DESCRIPTION
## Summary

Previously, create_task would always call generate_subtasks (AI) to auto-decompose every task into subtasks, even for simple ones. This was frustrating because the AI would always split tasks into ~4 subtasks regardless of complexity.

Now, subtasks are only created when the caller explicitly passes the subtasks parameter — i.e., when the user's text clearly indicates they want task decomposition.

## Changes

- Removed automatic AI subtask generation in TaskOrchestrator.create_task()`n- Kept the subtasks parameter path: when explicitly provided, subtasks are still created
- Removed unused generate_subtasks import

## Testing

- Existing API contract unchanged: subtasks parameter still works
- Default behavior (no subtasks param) now creates task without subtasks

Fixes gdyshi/todo-system#42