### PR TITLE
fix: restore DATABASE_URL in render.yaml to prevent Render Blueprint sync deletion

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,7 +13,9 @@ services:
     startCommand: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port $PORT"
     healthCheckPath: /health
     envVars:
-      # DATABASE_URL - 已迁移到 Neon，在 Render Dashboard 环境变量中配置
-      # 请勿在此处写入明文密码并提交到 GitHub
+      # DATABASE_URL 在 Render Dashboard 中配置（已迁移到 Neon）
+      # 此处保留 key 以防止 Render Blueprint 同步时删除该变量
+      - key: DATABASE_URL
+        value: ""  # 在 Render Dashboard 中设置实际的 Neon DB 连接字符串
       - key: PYTHON_VERSION
         value: "3.11.0"


### PR DESCRIPTION
## Summary

Fix Staging E2E test failure. Root cause: commit ed15fea commented out the DATABASE_URL env var in ender.yaml, causing Render Blueprint sync to delete the DATABASE_URL variable from the service, preventing the backend from starting.

Fix: Re-add DATABASE_URL key with empty value to ender.yaml to prevent Render from deleting it during Blueprint sync (actual value is configured in Render Dashboard).

## Changes

- ender.yaml: Restore DATABASE_URL env var declaration (empty value) to prevent Render Blueprint sync deletion

## Testing

- Local render.yaml syntax verified
- E2E test will run automatically after PR merge

Fixes gdyshi/todo-system#49