### PR TITLE
fix: Staging E2E Failed - 2026-06-21

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -75,11 +75,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install pnpm
-        run: npm install -g pnpm
-
       - name: Install dependencies
-        run: pnpm install
+        run: npm install
 
       - name: Install Playwright
         run: npx playwright install --with-deps chromium

--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,8 @@ services:
     healthCheckPath: /health
     envVars:
       # DATABASE_URL - 已迁移到 Neon，在 Render Dashboard 环境变量中配置
-      # 请勿在此处写入明文密码并提交到 GitHub
+      # sync: false 确保 Blueprint 不会删除或覆盖 Dashboard 中设置的值
+      - key: DATABASE_URL
+        sync: false
       - key: PYTHON_VERSION
         value: "3.11.0"


### PR DESCRIPTION
## Summary

Fix Staging E2E test failure reported in issues #49 and #50.

**Root Cause**: Commit ed15fea migrated the database to Neon but commented out the DATABASE_URL env var in ender.yaml, causing Render Blueprint sync to delete the DATABASE_URL variable from the service.

**Fix**: Two changes:
1. ender.yaml: Restore DATABASE_URL with sync: false to prevent Render Blueprint from overwriting/deleting the variable
2. .github/workflows/deploy-staging.yml: Replace pnpm with 
pm (pnpm may not be available in the CI runner)

## Changes

- ender.yaml: Add DATABASE_URL env var with sync: false
- .github/workflows/deploy-staging.yml: Use 
pm install instead of pnpm install

## Testing

- CI/CD checks run on PR
- E2E test will run automatically after PR merge to master

Fixes gdyshi/todo-system#49
Fixes gdyshi/todo-system#50